### PR TITLE
added odds ratio files based on the median lnL from timeseries CV

### DIFF
--- a/results/Cloutier/TimeSeriesCV/oddsratio_0001a.txt
+++ b/results/Cloutier/TimeSeriesCV/oddsratio_0001a.txt
@@ -1,0 +1,4 @@
+# Number of lnL evaluations, planet model denominator, planet model numerator, mode log10(odds ratio), median log10(odds ratio), minus 2 sigma (not used), minus 1 sigma, plus 1 sigma, plus 2 sigma (not used)
+1.6E+07,0,1,13.586254,13.586254,NaN,2.800272,2.800272,NaN
+1.6E+07,1,2,11.270942,11.270942,NaN,2.633130,2.633130,NaN
+1.6E+07,2,3,0.644174,0.644174,NaN,2.428479,2.428479,NaN

--- a/results/Cloutier/TimeSeriesCV/oddsratio_0001b.txt
+++ b/results/Cloutier/TimeSeriesCV/oddsratio_0001b.txt
@@ -1,0 +1,4 @@
+# Number of lnL evaluations, planet model denominator, planet model numerator, mode log10(odds ratio), median log10(odds ratio), minus 2 sigma (not used), minus 1 sigma, plus 1 sigma, plus 2 sigma (not used)
+1.6E+07,0,1,17.549655,17.549655,NaN,2.672230,2.672230,NaN
+1.6E+07,1,2,13.553605,13.553605,NaN,2.307381,2.307381,NaN
+1.6E+07,2,3,-17.048117,-17.048117,NaN,2.796629,2.796629,NaN

--- a/results/Cloutier/TimeSeriesCV/oddsratio_0002a.txt
+++ b/results/Cloutier/TimeSeriesCV/oddsratio_0002a.txt
@@ -1,0 +1,4 @@
+# Number of lnL evaluations, planet model denominator, planet model numerator, mode log10(odds ratio), median log10(odds ratio), minus 2 sigma (not used), minus 1 sigma, plus 1 sigma, plus 2 sigma (not used)
+1.6E+07,0,1,17.690626,17.690626,NaN,1.692424,1.692424,NaN
+1.6E+07,1,2,-20.830474,-20.830474,NaN,1.684262,1.684262,NaN
+1.6E+07,2,3,-inf,-inf,NaN,NaN,NaN,NaN

--- a/results/Cloutier/TimeSeriesCV/oddsratio_0002b.txt
+++ b/results/Cloutier/TimeSeriesCV/oddsratio_0002b.txt
@@ -1,0 +1,4 @@
+# Number of lnL evaluations, planet model denominator, planet model numerator, mode log10(odds ratio), median log10(odds ratio), minus 2 sigma (not used), minus 1 sigma, plus 1 sigma, plus 2 sigma (not used)
+1.6E+07,0,1,23.567933,23.567933,NaN,1.739989,1.739989,NaN
+1.6E+07,1,2,-inf,-inf,NaN,NaN,NaN,NaN
+1.6E+07,2,3,201.049890,201.049890,NaN,37.624382,37.624382,NaN

--- a/results/Cloutier/TimeSeriesCV/oddsratio_0003a.txt
+++ b/results/Cloutier/TimeSeriesCV/oddsratio_0003a.txt
@@ -1,0 +1,4 @@
+# Number of lnL evaluations, planet model denominator, planet model numerator, mode log10(odds ratio), median log10(odds ratio), minus 2 sigma (not used), minus 1 sigma, plus 1 sigma, plus 2 sigma (not used)
+1.6E+07,0,1,4.531654,4.531654,NaN,1.262842,1.262842,NaN
+1.6E+07,1,2,-0.678730,-0.678730,NaN,1.225237,1.225237,NaN
+1.6E+07,2,3,-1.439452,-1.439452,NaN,1.140773,1.140773,NaN

--- a/results/Cloutier/TimeSeriesCV/oddsratio_0003b.txt
+++ b/results/Cloutier/TimeSeriesCV/oddsratio_0003b.txt
@@ -1,0 +1,4 @@
+# Number of lnL evaluations, planet model denominator, planet model numerator, mode log10(odds ratio), median log10(odds ratio), minus 2 sigma (not used), minus 1 sigma, plus 1 sigma, plus 2 sigma (not used)
+1.6E+07,0,1,1.454308,1.454308,NaN,1.385816,1.385816,NaN
+1.6E+07,1,2,1.830239,1.830239,NaN,1.299376,1.299376,NaN
+1.6E+07,2,3,-10.664316,-10.664316,NaN,1.455064,1.455064,NaN

--- a/results/Cloutier/TimeSeriesCV/oddsratio_0004a.txt
+++ b/results/Cloutier/TimeSeriesCV/oddsratio_0004a.txt
@@ -1,0 +1,4 @@
+# Number of lnL evaluations, planet model denominator, planet model numerator, mode log10(odds ratio), median log10(odds ratio), minus 2 sigma (not used), minus 1 sigma, plus 1 sigma, plus 2 sigma (not used)
+1.6E+07,0,1,-1.267791,-1.267791,NaN,1.419915,1.419915,NaN
+1.6E+07,1,2,-3.608423,-3.608423,NaN,1.523190,1.523190,NaN
+1.6E+07,2,3,-2.326236,-2.326236,NaN,1.575085,1.575085,NaN

--- a/results/Cloutier/TimeSeriesCV/oddsratio_0004b.txt
+++ b/results/Cloutier/TimeSeriesCV/oddsratio_0004b.txt
@@ -1,0 +1,4 @@
+# Number of lnL evaluations, planet model denominator, planet model numerator, mode log10(odds ratio), median log10(odds ratio), minus 2 sigma (not used), minus 1 sigma, plus 1 sigma, plus 2 sigma (not used)
+1.6E+07,0,1,-3.248039,-3.248039,NaN,1.500460,1.500460,NaN
+1.6E+07,1,2,-8.494058,-8.494058,NaN,1.824662,1.824662,NaN
+1.6E+07,2,3,-4.698531,-4.698531,NaN,2.287391,2.287391,NaN

--- a/results/Cloutier/TimeSeriesCV/oddsratio_0005a.txt
+++ b/results/Cloutier/TimeSeriesCV/oddsratio_0005a.txt
@@ -1,0 +1,4 @@
+# Number of lnL evaluations, planet model denominator, planet model numerator, mode log10(odds ratio), median log10(odds ratio), minus 2 sigma (not used), minus 1 sigma, plus 1 sigma, plus 2 sigma (not used)
+1.6E+07,0,1,4.047218,4.047218,NaN,2.004590,2.004590,NaN
+1.6E+07,1,2,-0.019999,-0.019999,NaN,1.876000,1.876000,NaN
+1.6E+07,2,3,-3.599325,-3.599325,NaN,2.005228,2.005228,NaN

--- a/results/Cloutier/TimeSeriesCV/oddsratio_0005b.txt
+++ b/results/Cloutier/TimeSeriesCV/oddsratio_0005b.txt
@@ -1,0 +1,4 @@
+# Number of lnL evaluations, planet model denominator, planet model numerator, mode log10(odds ratio), median log10(odds ratio), minus 2 sigma (not used), minus 1 sigma, plus 1 sigma, plus 2 sigma (not used)
+1.6E+07,0,1,6.020410,6.020410,NaN,1.868563,1.868563,NaN
+1.6E+07,1,2,4.318444,4.318444,NaN,1.356273,1.356273,NaN
+1.6E+07,2,3,-11.561053,-11.561053,NaN,1.853239,1.853239,NaN

--- a/results/Cloutier/TimeSeriesCV/oddsratio_0006a.txt
+++ b/results/Cloutier/TimeSeriesCV/oddsratio_0006a.txt
@@ -1,0 +1,4 @@
+# Number of lnL evaluations, planet model denominator, planet model numerator, mode log10(odds ratio), median log10(odds ratio), minus 2 sigma (not used), minus 1 sigma, plus 1 sigma, plus 2 sigma (not used)
+1.6E+07,0,1,-0.319094,-0.319094,NaN,1.983738,1.983738,NaN
+1.6E+07,1,2,1.836741,1.836741,NaN,1.980183,1.980183,NaN
+1.6E+07,2,3,-4.752756,-4.752756,NaN,2.066791,2.066791,NaN

--- a/results/Cloutier/TimeSeriesCV/oddsratio_0006b.txt
+++ b/results/Cloutier/TimeSeriesCV/oddsratio_0006b.txt
@@ -1,0 +1,4 @@
+# Number of lnL evaluations, planet model denominator, planet model numerator, mode log10(odds ratio), median log10(odds ratio), minus 2 sigma (not used), minus 1 sigma, plus 1 sigma, plus 2 sigma (not used)
+1.6E+07,0,1,1.812934,1.812934,NaN,1.957947,1.957947,NaN
+1.6E+07,1,2,-1.693850,-1.693850,NaN,1.912667,1.912667,NaN
+1.6E+07,2,3,-0.423904,-0.423904,NaN,1.810404,1.810404,NaN


### PR DESCRIPTION
I've combined the median lnLs from timeseries CV and scaled them to the size of the full RV dataset (N=200). I then computed the resulting likelihood ratios which are given in the new oddsratio txt files. These values are used to compare competing models, similar to the fully marginalized likelihood, but do not include the marginalization over the model parameter space and therefore differ in scale from the numerical value of the Bayes factor for the same dataset. I believe that the qualitative results from timeseries CV are consistent with the results from the Bayesian evidence ratios in that they favour the same model. However, I cannot confirm that this is universally true before seeing the results of all other analyses on each RV dataset.